### PR TITLE
Expose all indices from ESI

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,5 +14,14 @@
     "slack": true,
     "discord": false
   },
+  "enabled_indices": {
+    "manufacturing": true,
+    "reaction": true,
+    "researching_material_efficiency": false,
+    "researching_time_efficiency": false,
+    "invention": false,
+    "copying": false
+  },
+  "verbose": true,
   "display_threshold": 0.01
 }


### PR DESCRIPTION
 - instead of only Manufacturing & Reaction, also expose ME Research, TE Research, Invention, and Copying
 - refactor to remove duplicated code calls
 - 100% backwards compatibility is the goal
 - new config.json values are all opt-in verbose=true prints to stdout only "enabled_indices" will be displayed/posted manufacturing/reaction default to true, new ones to false

The main problem I see right now is that with the current formatting the bot would spam approximately 6*40 lines instead of the current 2*40 lines. The Slack webhook doesn't seem to support posting to Threads. One idea could be to format 2 or 3 wide, (but this is not implemented) like so:

But as everything should be backwards compatible people could at least run this on their own with a different config.

```
X          Y
U 3%       U 2%
U 3%       U 2%
U 3%       U 2%



X          Y          Z
U 3%       U 2%       U 1%
U 3%       U 2%       U 1%
U 3%       U 2%       U 1%

```